### PR TITLE
changed $_mail to $mail

### DIFF
--- a/classes/email/core.php
+++ b/classes/email/core.php
@@ -12,7 +12,7 @@ class Email_Core {
   /**
    * @var  Swiftmailer  Holds Swiftmailer instance
    */
-	protected static $_mail;
+	protected static $mail;
 
 	/**
 	 * Creates a SwiftMailer instance.


### PR DESCRIPTION
kohana produces static method exception due to erroneous variable name.
