### PR TITLE
Error on windows systems due to wrong directory slash (forward slash vs. backslash)

### DIFF
--- a/init.php
+++ b/init.php
@@ -1,4 +1,4 @@
 <?php defined('SYSPATH') or die('No direct script access.');
 
 // Load Swiftmailer
-include Kohana::find_file('vendor', 'swiftmailer/lib/swift_required', 'php');
+include Kohana::find_file('vendor', 'swiftmailer'.DIRECTORY_SEPARATOR.'lib'.DIRECTORY_SEPARATOR.'swift_required', 'php');


### PR DESCRIPTION
Added in the DIRECTORY_SEPARATOR constant so it will work properly on Windows and UNIX.
